### PR TITLE
Develop notice tag filter

### DIFF
--- a/KWNotice.xcodeproj/project.pbxproj
+++ b/KWNotice.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		871F83382C1FFDA9006C9685 /* SelectNoticeTagViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871F83372C1FFDA9006C9685 /* SelectNoticeTagViewModel.swift */; };
+		871F833A2C1FFDB0006C9685 /* SelectNoticeTagView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871F83392C1FFDB0006C9685 /* SelectNoticeTagView.swift */; };
+		871F833C2C1FFDCC006C9685 /* NoticeTagCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 871F833B2C1FFDCC006C9685 /* NoticeTagCell.swift */; };
 		A51EC35428791211000A1FC7 /* FavoriteNotice.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = A51EC35228791211000A1FC7 /* FavoriteNotice.xcdatamodeld */; };
 		A51EC3562879127E000A1FC7 /* FavoriteNoticeDataStoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51EC3552879127E000A1FC7 /* FavoriteNoticeDataStoreProtocol.swift */; };
 		A51EC3582879130A000A1FC7 /* LocalFavoriteNoticeDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A51EC3572879130A000A1FC7 /* LocalFavoriteNoticeDataStore.swift */; };
@@ -120,6 +123,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		871F83372C1FFDA9006C9685 /* SelectNoticeTagViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectNoticeTagViewModel.swift; sourceTree = "<group>"; };
+		871F83392C1FFDB0006C9685 /* SelectNoticeTagView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectNoticeTagView.swift; sourceTree = "<group>"; };
+		871F833B2C1FFDCC006C9685 /* NoticeTagCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeTagCell.swift; sourceTree = "<group>"; };
 		A51EC35328791211000A1FC7 /* FavoriteNotice.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = FavoriteNotice.xcdatamodel; sourceTree = "<group>"; };
 		A51EC3552879127E000A1FC7 /* FavoriteNoticeDataStoreProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteNoticeDataStoreProtocol.swift; sourceTree = "<group>"; };
 		A51EC3572879130A000A1FC7 /* LocalFavoriteNoticeDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFavoriteNoticeDataStore.swift; sourceTree = "<group>"; };
@@ -226,6 +232,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		871F83362C1FFD8D006C9685 /* SelectNoticeTag */ = {
+			isa = PBXGroup;
+			children = (
+				871F83372C1FFDA9006C9685 /* SelectNoticeTagViewModel.swift */,
+				871F83392C1FFDB0006C9685 /* SelectNoticeTagView.swift */,
+			);
+			path = SelectNoticeTag;
+			sourceTree = "<group>";
+		};
 		A51EC350287911FB000A1FC7 /* Favorite */ = {
 			isa = PBXGroup;
 			children = (
@@ -289,6 +304,7 @@
 				A56FC6AA28943B4C00AF724B /* SafariView.swift */,
 				A5C92962287814A7000AE7EA /* Extensions */,
 				A525CC072893637D004B45D8 /* NoSearchResultView.swift */,
+				871F833B2C1FFDCC006C9685 /* NoticeTagCell.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -453,6 +469,7 @@
 			children = (
 				A57A253B286D702E002DB735 /* RootView.swift */,
 				A54EC211287402C800FF03E1 /* KWHomeNotice */,
+				871F83362C1FFD8D006C9685 /* SelectNoticeTag */,
 				A54EC21E28743F3F00FF03E1 /* SWCentralNotice */,
 				A57A2548286D7645002DB735 /* Favorite */,
 				A57A2549286D7648002DB735 /* Setting */,
@@ -803,6 +820,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A54EC22028743F4E00FF03E1 /* SWCentralNoticeViewModel.swift in Sources */,
+				871F833A2C1FFDB0006C9685 /* SelectNoticeTagView.swift in Sources */,
 				A57A254D286D7661002DB735 /* FavoriteView.swift in Sources */,
 				A56FC6AB28943B4C00AF724B /* SafariView.swift in Sources */,
 				A5C92968287815A3000AE7EA /* Notification+CoreDataProperties.swift in Sources */,
@@ -821,7 +839,9 @@
 				A5C92964287814B2000AE7EA /* Date+.swift in Sources */,
 				A525CC082893637D004B45D8 /* NoSearchResultView.swift in Sources */,
 				A5B8C0A02872964D0042E3C5 /* DependencyContainer.swift in Sources */,
+				871F833C2C1FFDCC006C9685 /* NoticeTagCell.swift in Sources */,
 				A5E89937286D9EFE009EE85E /* AppDelegate.swift in Sources */,
+				871F83382C1FFDA9006C9685 /* SelectNoticeTagViewModel.swift in Sources */,
 				A54EC21628741D1300FF03E1 /* AlertPublishableObject.swift in Sources */,
 				A5C92967287815A3000AE7EA /* Notification+CoreDataClass.swift in Sources */,
 				A57A253C286D702E002DB735 /* RootView.swift in Sources */,

--- a/KWNotice/Components/NoticeTagCell.swift
+++ b/KWNotice/Components/NoticeTagCell.swift
@@ -1,0 +1,8 @@
+//
+//  NoticeTagCell.swift
+//  KWNotice
+//
+//  Created by 장석우 on 6/17/24.
+//
+
+import Foundation

--- a/KWNotice/Components/NoticeTagCell.swift
+++ b/KWNotice/Components/NoticeTagCell.swift
@@ -2,7 +2,49 @@
 //  NoticeTagCell.swift
 //  KWNotice
 //
-//  Created by 장석우 on 6/17/24.
+//  Created by 장석우 on 6/14/24.
 //
 
-import Foundation
+import SwiftUI
+import KWNoticeKit
+
+struct NoticeTagCell: View {
+    
+    let title: String
+    @Binding var selectedNoticeTag: String
+    
+    var body: some View {
+        HStack() {
+            Text(title)
+                .fontWeight(.medium)
+                .lineLimit(1)
+                .frame(minWidth: 0, maxWidth: .infinity, alignment: .leading)
+            
+            Image(systemName: "checkmark")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: 16)
+                .foregroundColor(.accentColor)
+                .opacity(title == selectedNoticeTag ? 1 : 0)
+        }
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selectedNoticeTag = title
+        }
+    }
+}
+
+fileprivate extension NoticeTagCell {
+    init(mockTitle: String) {
+        self.title = mockTitle
+        self._selectedNoticeTag = .constant("Mock")
+    }
+}
+
+struct NoticeTypeCell_Previews: PreviewProvider {
+    static var previews: some View {
+        NoticeTagCell(mockTitle: "전체")
+    }
+}
+

--- a/KWNotice/View/KWHomeNotice/KWHomeNoticeView.swift
+++ b/KWNotice/View/KWHomeNotice/KWHomeNoticeView.swift
@@ -16,6 +16,10 @@ struct KWHomeNoticeView: View {
     
     @State private var searchText = ""
     @State private var isSearching = false
+    @State private var presentingSelectTagView = false
+    
+    @State var selectedNoticeTag = "전체"
+        
     
     var body: some View {
         NavigationView {
@@ -50,9 +54,19 @@ struct KWHomeNoticeView: View {
                 placement: .navigationBarDrawer(displayMode: .always),
                 prompt: "공지 검색"
             )
+            .toolbar {
+                Button(selectedNoticeTag) { self.presentingSelectTagView = true }
+                    .sheet(isPresented: $presentingSelectTagView, content: {
+                        SelectNoticeTagView(selectedNoticeTag: $selectedNoticeTag)
+                    })
+            }
             .onChange(of: searchText) { newValue in
                 isSearching = !newValue.isEmpty
                 viewModel.search(text: newValue)
+            }
+            .onChange(of: selectedNoticeTag) { selectedTag in
+                self.presentingSelectTagView = false
+                viewModel.filter(by: selectedTag)
             }
             .navigationTitle("광운대학교 공지")
     }

--- a/KWNotice/View/KWHomeNotice/KWHomeNoticeViewModel.swift
+++ b/KWNotice/View/KWHomeNotice/KWHomeNoticeViewModel.swift
@@ -43,6 +43,10 @@ final class KWHomeNoticeViewModel: AlertPublishableObject, ObservableObject {
         }
     }
     
+    func filter(by tag: String) {
+        notices = repository.filter(by: tag)
+    }
+
     func refresh() async {
         isAlreadyFetched = false
         await fetch()

--- a/KWNotice/View/SelectNoticeTag/SelectNoticeTagView.swift
+++ b/KWNotice/View/SelectNoticeTag/SelectNoticeTagView.swift
@@ -1,0 +1,8 @@
+//
+//  SelectNoticeTagView.swift
+//  KWNotice
+//
+//  Created by 장석우 on 6/17/24.
+//
+
+import Foundation

--- a/KWNotice/View/SelectNoticeTag/SelectNoticeTagView.swift
+++ b/KWNotice/View/SelectNoticeTag/SelectNoticeTagView.swift
@@ -1,8 +1,54 @@
 //
-//  SelectNoticeTagView.swift
+//  SelectNoticeTypeView.swift
 //  KWNotice
 //
-//  Created by 장석우 on 6/17/24.
+//  Created by 장석우 on 6/14/24.
 //
 
-import Foundation
+import SwiftUI
+import SafariServices
+import KWNoticeKit
+
+struct SelectNoticeTagView: View {
+    
+    @StateObject var viewModel = SelectNoticeTagViewModel()
+    
+    @Binding var selectedNoticeTag: String
+    
+    var body: some View {
+        NavigationView {
+            switch viewModel.state {
+            case .none:
+                noticeTagList
+            case .fetching:
+                ProgressView()
+            case .error:
+                PlaceholderView(navigationTitle: "") {
+                    viewModel.refresh()
+                }
+            }
+        }
+        .task { viewModel.fetch() }
+        .alert(viewModel.alertMessage, isPresented: $viewModel.isPresented) {
+            Button("확인") {}
+        }
+        .navigationViewStyle(.stack)
+    }
+    
+    var noticeTagList: some View {
+        List {
+            ForEach(viewModel.tags, id: \.self ) { tag in
+                NoticeTagCell(title: tag, selectedNoticeTag: $selectedNoticeTag)
+            }
+        }
+        .listStyle(.plain)
+        
+    }
+    
+}
+
+struct SelectNoticeTypeView_Previews: PreviewProvider {
+    static var previews: some View {
+        return KWHomeNoticeView()
+    }
+}

--- a/KWNotice/View/SelectNoticeTag/SelectNoticeTagViewModel.swift
+++ b/KWNotice/View/SelectNoticeTag/SelectNoticeTagViewModel.swift
@@ -1,0 +1,8 @@
+//
+//  SelectNoticeTagViewModel.swift
+//  KWNotice
+//
+//  Created by 장석우 on 6/17/24.
+//
+
+import Foundation

--- a/KWNotice/View/SelectNoticeTag/SelectNoticeTagViewModel.swift
+++ b/KWNotice/View/SelectNoticeTag/SelectNoticeTagViewModel.swift
@@ -1,8 +1,41 @@
 //
-//  SelectNoticeTagViewModel.swift
+//  SelectNoticeTypeViewModel.swift
 //  KWNotice
 //
-//  Created by 장석우 on 6/17/24.
+//  Created by 장석우 on 6/14/24.
 //
 
 import Foundation
+import Combine
+import KWNoticeKit
+
+@MainActor
+final class SelectNoticeTagViewModel: AlertPublishableObject, ObservableObject {
+    
+    enum State {
+        case none
+        case fetching
+        case error
+    }
+    
+    // MARK: - Properties
+    
+    //TODO: DependencyContainer 의 dependencies [String: Any] 에서 가져오기에, Home에서 생성된 KWHomeRepository을 가져온다. (같은 인스턴스 참조)
+    @Resolve private var repository: KWHomeRepositoryProtocol
+    @Published var tags = ["전체"]
+    
+    private(set) var state = State.none
+    
+    // MARK: - Methods
+    
+    func fetch() {
+        state = .fetching
+        tags = ["전체"] + repository.getTag() //TODO: Home에서 Notice 데이터 가져오기 전에 getTag를 호출한다면 빈배열이 반환될 것이다.
+        state = .none
+    }
+    
+    func refresh() {
+        fetch()
+    }
+
+}

--- a/KWNoticeKit/Repository/KWHome/KWHomeRepository.swift
+++ b/KWNoticeKit/Repository/KWHome/KWHomeRepository.swift
@@ -25,6 +25,15 @@ public final class KWHomeRepository: KWHomeRepositoryProtocol {
         return notices.sorted(by: >)
     }
     
+    public func filter(by tag: String) -> [KWHomeNotice] {
+        guard tag != "전체" else { return notices }
+        return notices.filter { $0.tag == tag}
+    }
+    
+    public func getTag() -> [String] {
+        return Array(Set(notices.map { $0.tag })).sorted(by: >)
+    }
+    
     public func search(text: String) -> [KWHomeNotice] {
         if text.isEmpty { return notices }
         

--- a/KWNoticeKit/Repository/KWHome/KWHomeRepositoryProtocol.swift
+++ b/KWNoticeKit/Repository/KWHome/KWHomeRepositoryProtocol.swift
@@ -10,5 +10,7 @@ import Combine
 
 public protocol KWHomeRepositoryProtocol {
     func fetch() async throws -> [KWHomeNotice]
+    func filter(by tag: String) -> [KWHomeNotice]
+    func getTag() -> [String]
     func search(text: String) -> [KWHomeNotice]
 }


### PR DESCRIPTION
closed: #57 

### 
![filterTag](https://github.com/kw-service/kw-notice-ios-v1/assets/57269348/e53a7727-e0e3-4918-9d20-6c1891b40f70)

### Description
- Make filtering notice by tag.
- Use `set` to get unique tags from the notice data.
- Handling fetch error in the **SelectTagView** has not been implemented yet.
